### PR TITLE
Implement client authoritive player spawning

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -28,3 +28,4 @@ project/assembly_name="godot-multiplayer"
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+environment/defaults/default_clear_color=Color(0.897869, 0.798916, 0.75584, 1)

--- a/scenes/levels/playground.tscn
+++ b/scenes/levels/playground.tscn
@@ -6,10 +6,9 @@
 
 [node name="playground" type="Node2D"]
 
-[node name="Lobby" type="Node" parent="." node_paths=PackedStringArray("playerSpawner", "clientListDebugLabel")]
+[node name="Lobby" type="Node" parent="." node_paths=PackedStringArray("clientListDebugLabel")]
 script = ExtResource("1_62it3")
 playerScene = ExtResource("2_o8weq")
-playerSpawner = NodePath("")
 clientListDebugLabel = NodePath("client_list")
 
 [node name="client_list" type="Label" parent="Lobby"]

--- a/scenes/levels/playground.tscn
+++ b/scenes/levels/playground.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dcm5jeu2yntyw" path="res://scripts/Lobby.cs" id="1_62it3"]
 [ext_resource type="PackedScene" uid="uid://c5ywqhagg4clt" path="res://scenes/prefabs/lobby_menu.tscn" id="2_n6048"]
-[ext_resource type="PackedScene" uid="uid://ck7p465jbsvgd" path="res://scenes/prefabs/player.tscn" id="2_o8weq"]
+[ext_resource type="PackedScene" uid="uid://bpo3sey3ddxkt" path="res://scenes/prefabs/demo_player.tscn" id="2_o8weq"]
 
 [node name="playground" type="Node2D"]
 

--- a/scenes/levels/playground.tscn
+++ b/scenes/levels/playground.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=3 format=3 uid="uid://dohsyq8q6amsn"]
+[gd_scene load_steps=4 format=3 uid="uid://dohsyq8q6amsn"]
 
 [ext_resource type="Script" uid="uid://dcm5jeu2yntyw" path="res://scripts/Lobby.cs" id="1_62it3"]
 [ext_resource type="PackedScene" uid="uid://c5ywqhagg4clt" path="res://scenes/prefabs/lobby_menu.tscn" id="2_n6048"]
+[ext_resource type="PackedScene" uid="uid://ck7p465jbsvgd" path="res://scenes/prefabs/player.tscn" id="2_o8weq"]
 
 [node name="playground" type="Node2D"]
 
-[node name="Lobby" type="Node" parent="." node_paths=PackedStringArray("clientListDebugLabel")]
+[node name="Lobby" type="Node" parent="." node_paths=PackedStringArray("playerSpawner", "clientListDebugLabel")]
 script = ExtResource("1_62it3")
+playerScene = ExtResource("2_o8weq")
+playerSpawner = NodePath("")
 clientListDebugLabel = NodePath("client_list")
 
 [node name="client_list" type="Label" parent="Lobby"]

--- a/scenes/prefabs/demo_player.tscn
+++ b/scenes/prefabs/demo_player.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=4 format=3 uid="uid://bpo3sey3ddxkt"]
+
+[ext_resource type="Script" uid="uid://b4ovw8hv3r1mw" path="res://scripts/DemoPlayer.cs" id="1_hxrn8"]
+[ext_resource type="Texture2D" uid="uid://cwyq3x3mlmya7" path="res://assets/icon.svg" id="2_mvngi"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_mvngi"]
+
+[node name="DemoPlayer" type="RigidBody2D" node_paths=PackedStringArray("sprite", "remotePositionDebug")]
+script = ExtResource("1_hxrn8")
+sprite = NodePath("Sprite2D")
+positionSyncPerSecond = 8.0
+remotePositionDebug = NodePath("Sprite2D2")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2_mvngi")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+scale = Vector2(6, 6)
+shape = SubResource("RectangleShape2D_mvngi")
+disabled = true
+
+[node name="Sprite2D2" type="Sprite2D" parent="."]
+modulate = Color(0, 0, 0, 1)
+z_index = 1
+scale = Vector2(0.2, 0.2)
+texture = ExtResource("2_mvngi")

--- a/scenes/prefabs/lobby_menu.tscn
+++ b/scenes/prefabs/lobby_menu.tscn
@@ -9,6 +9,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 script = ExtResource("1_rtcxu")
 textEdit = NodePath("MarginContainer/VBoxContainer/password")
 

--- a/scenes/prefabs/player.tscn
+++ b/scenes/prefabs/player.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://ck7p465jbsvgd"]
+
+[ext_resource type="Texture2D" uid="uid://cwyq3x3mlmya7" path="res://assets/icon.svg" id="1_06qtw"]
+
+[node name="player" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("1_06qtw")

--- a/scripts/Client.cs
+++ b/scripts/Client.cs
@@ -19,8 +19,6 @@ public partial class Client : RefCounted, IBlittable
 	// Player node belonging to this client.
 	protected Node playerInstance;
 
-	public float debug_reg_time;
-
 	/*********************************************************************************************/
 	/** Constructor */
 
@@ -32,22 +30,19 @@ public partial class Client : RefCounted, IBlittable
 	/*********************************************************************************************/
 	/** Client Registration */
 
-	public virtual void OnRegisterClient()
+	public virtual void OnRegisterClient(Node clientRoot, PackedScene playerPrefab) // This kind of sucks
 	{
 		// Spawn in your player character, etc
-		GD.Print("!!!reg client!!!");
-		debug_reg_time = (float)Time.GetTicksMsec() / 1000f;
-	}
+		playerInstance = playerPrefab.Instantiate<Node>();
+		playerInstance.SetMultiplayerAuthority(networkID);
 
-	public float DEBUG_GetLifetime()
-	{
-		return ((float)Time.GetTicksMsec() / 1000f) - debug_reg_time;
+		clientRoot.AddChild(playerInstance);
 	}
 
 	public virtual void OnUnregisterClient()
 	{
 		// Destroy your player character, etc
-		GD.Print("!!!unreg client!!!");
+		playerInstance.QueueFree();
 	}
 
 	/*********************************************************************************************/

--- a/scripts/Client.cs
+++ b/scripts/Client.cs
@@ -19,6 +19,8 @@ public partial class Client : RefCounted, IBlittable
 	// Player node belonging to this client.
 	protected Node playerInstance;
 
+	public float debug_reg_time;
+
 	/*********************************************************************************************/
 	/** Constructor */
 
@@ -30,15 +32,23 @@ public partial class Client : RefCounted, IBlittable
 	/*********************************************************************************************/
 	/** Client Registration */
 
-	// public virtual void OnRegisterClient()
-	// {
-	// 	GD.Print("reg client");
-	// }
+	public virtual void OnRegisterClient()
+	{
+		// Spawn in your player character, etc
+		GD.Print("!!!reg client!!!");
+		debug_reg_time = (float)Time.GetTicksMsec() / 1000f;
+	}
 
-	// public virtual void OnUnregisterClient()
-	// {
-	// 	GD.Print("unreg client");
-	// }
+	public float DEBUG_GetLifetime()
+	{
+		return ((float)Time.GetTicksMsec() / 1000f) - debug_reg_time;
+	}
+
+	public virtual void OnUnregisterClient()
+	{
+		// Destroy your player character, etc
+		GD.Print("!!!unreg client!!!");
+	}
 
 	/*********************************************************************************************/
 	/** Getters / Setters */

--- a/scripts/Client.cs
+++ b/scripts/Client.cs
@@ -1,6 +1,10 @@
 using Godot;
 using System;
 
+/// <summary>
+/// Clients are objects that represent an authenticated connection to the server.
+/// By default, each client spawns a player node which they have network authority over.
+/// </summary>
 [Serializable]
 public partial class Client : RefCounted, IBlittable
 {
@@ -30,7 +34,7 @@ public partial class Client : RefCounted, IBlittable
 	/*********************************************************************************************/
 	/** Client Registration */
 
-	public virtual void OnRegisterClient(Node clientRoot, PackedScene playerPrefab) // This kind of sucks
+	public virtual void OnRegisterClient(Node root, PackedScene playerPrefab)
 	{
 		// Spawn in your player character, etc
 		playerInstance = playerPrefab.Instantiate<Node>();
@@ -38,7 +42,7 @@ public partial class Client : RefCounted, IBlittable
 
 		playerInstance.Name = String.Format("client_{0}", networkID);
 
-		clientRoot.AddChild(playerInstance);
+		root.AddChild(playerInstance);
 	}
 
 	public virtual void OnUnregisterClient()
@@ -49,11 +53,6 @@ public partial class Client : RefCounted, IBlittable
 
 	/*********************************************************************************************/
 	/** Getters / Setters */
-
-	public void SetPlayer(Node newPlayerInstance)
-	{
-		playerInstance = newPlayerInstance;
-	}
 
 	public int GetNetworkID()
 	{
@@ -81,5 +80,4 @@ public partial class Client : RefCounted, IBlittable
 	{
 		return new Client(networkID);
 	}
-
 }

--- a/scripts/Client.cs
+++ b/scripts/Client.cs
@@ -16,6 +16,9 @@ public partial class Client : RefCounted, IBlittable
 	[Export]
 	protected float connectTime;
 
+	// Player node belonging to this client.
+	protected Node playerInstance;
+
 	/*********************************************************************************************/
 	/** Constructor */
 
@@ -25,11 +28,34 @@ public partial class Client : RefCounted, IBlittable
 	}
 
 	/*********************************************************************************************/
+	/** Client Registration */
+
+	// public virtual void OnRegisterClient()
+	// {
+	// 	GD.Print("reg client");
+	// }
+
+	// public virtual void OnUnregisterClient()
+	// {
+	// 	GD.Print("unreg client");
+	// }
+
+	/*********************************************************************************************/
 	/** Getters / Setters */
+
+	public void SetPlayer(Node newPlayerInstance)
+	{
+		playerInstance = newPlayerInstance;
+	}
 
 	public int GetNetworkID()
 	{
 		return networkID;
+	}
+
+	public Node GetPlayer()
+	{
+		return playerInstance;
 	}
 
 	/*********************************************************************************************/

--- a/scripts/Client.cs
+++ b/scripts/Client.cs
@@ -36,6 +36,8 @@ public partial class Client : RefCounted, IBlittable
 		playerInstance = playerPrefab.Instantiate<Node>();
 		playerInstance.SetMultiplayerAuthority(networkID);
 
+		playerInstance.Name = String.Format("client_{0}", networkID);
+
 		clientRoot.AddChild(playerInstance);
 	}
 

--- a/scripts/DemoPlayer.cs
+++ b/scripts/DemoPlayer.cs
@@ -1,0 +1,108 @@
+using Godot;
+using System;
+
+public partial class DemoPlayer : RigidBody2D
+{
+	[Export]
+	protected Sprite2D sprite;
+
+	[Export]
+	protected float speed = 128f;
+
+	[ExportGroup("Synchronization (local)")]
+
+	[Export]
+	protected float positionSyncPerSecond = 10;
+
+	private float nextSyncTime = 0;
+
+	[ExportGroup("Synchronization (remote)")]
+
+	protected Vector2 remotePosition;
+
+	[Export]
+	protected float snapToPositionDistance = 128f;
+
+	[Export]
+	protected Node2D remotePositionDebug;
+
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready()
+	{
+		GravityScale = 0.0f;
+	}
+
+	// Called every frame. 'delta' is the elapsed time since the previous frame.
+	public override void _Process(double delta)
+	{
+		if (Multiplayer.HasMultiplayerPeer() && IsMultiplayerAuthority())
+		{
+			ProcessLocal((float)delta);
+		}
+		else
+		{
+			ProcessRemote((float)delta);
+		}
+
+	}
+
+	protected virtual void ProcessRemote(float delta)
+	{
+		sprite.Modulate = new Color(0.5f, 0.5f, 0.5f, 1f);
+
+		float distanceSq = remotePosition.DistanceSquaredTo(Position);
+
+		if (distanceSq > snapToPositionDistance * snapToPositionDistance)
+		{
+			Position = remotePosition;
+		}
+
+		Position = Position.Lerp(remotePosition, delta * 8f);
+		remotePositionDebug.GlobalPosition = remotePosition;
+	}
+
+	protected virtual void ProcessLocal(float delta)
+	{
+		if (Input.IsActionPressed("ui_left"))
+		{
+			LinearVelocity += Vector2.Left * delta * speed;
+		}
+		if (Input.IsActionPressed("ui_right"))
+		{
+			LinearVelocity += Vector2.Right * delta * speed;
+		}
+		if (Input.IsActionPressed("ui_up"))
+		{
+			LinearVelocity += Vector2.Up * delta * speed;
+		}
+		if (Input.IsActionPressed("ui_down"))
+		{
+			LinearVelocity += Vector2.Down * delta * speed;
+		}
+
+		float timeSeconds = (float)Time.GetTicksMsec() / 1000f;
+		if (timeSeconds > nextSyncTime)
+		{
+			nextSyncTime = timeSeconds + (1f / positionSyncPerSecond);
+			Command_SendPosition(Position);
+		}
+
+	}
+
+	[Rpc(MultiplayerApi.RpcMode.Authority, CallLocal = false, TransferMode = MultiplayerPeer.TransferModeEnum.UnreliableOrdered)]
+	protected void RPC_SyncPosition(Vector2 newPosition)
+	{
+		if (IsMultiplayerAuthority())
+		{
+			return;
+		}
+		remotePosition = newPosition;
+	}
+
+	[Rpc(MultiplayerApi.RpcMode.AnyPeer, CallLocal = false, TransferMode = MultiplayerPeer.TransferModeEnum.UnreliableOrdered)]
+	private void Command_SendPosition(Vector2 newPosition)
+	{
+		remotePosition = newPosition;
+		Rpc(MethodName.RPC_SyncPosition, newPosition);
+	}
+}

--- a/scripts/DemoPlayer.cs.uid
+++ b/scripts/DemoPlayer.cs.uid
@@ -1,0 +1,1 @@
+uid://b4ovw8hv3r1mw

--- a/scripts/Lobby.cs
+++ b/scripts/Lobby.cs
@@ -39,6 +39,8 @@ public partial class Lobby : Node
 	/*********************************************************************************************/
 	/** Lobby */
 
+	[ExportGroup("Lobby Configuration")]
+
 	// Mapping of unique ID's to client information.
 	protected Dictionary<int, Client> clients = new Dictionary<int, Client>();
 
@@ -59,15 +61,12 @@ public partial class Lobby : Node
 	protected string password = "";
 
 	// Time in seconds that server must receive authentication info from clients before kicking.
+	[Export]
 	protected float maxAuthenticationTime = 1.0f;
 
 	// Player scene. Every client has one spawned player scene that they control.
 	[Export]
 	protected PackedScene playerScene;
-
-	// TODO : Maybe use this? It seems like we can just do this manually and then users only need to configure one node 
-	[Export]
-	protected MultiplayerSpawner playerSpawner;
 
 	/*********************************************************************************************/
 	/** Egnine Methods */
@@ -147,6 +146,8 @@ public partial class Lobby : Node
 		Multiplayer.MultiplayerPeer = peer;
 		GD.Print(String.Format("Hosting server @ {0}:{1}.", bindIP, port));
 
+		// EnableUPNP(port);
+
 		return Error.Ok;
 	}
 
@@ -180,6 +181,7 @@ public partial class Lobby : Node
 		}
 
 		Multiplayer.MultiplayerPeer.Close();
+		// DisableUPNP(port);
 
 		return Error.Ok;
 	}
@@ -187,6 +189,22 @@ public partial class Lobby : Node
 	public virtual void SetPassword(string newPassword)
 	{
 		password = newPassword;
+	}
+	/*********************************************************************************************/
+	/** UPNP */
+
+	private Upnp upnp;
+
+	protected void EnableUPNP(int port)
+	{
+		upnp = new Upnp();
+		upnp.Discover();
+		upnp.AddPortMapping(port);
+	}
+
+	protected void DisableUPNP(int port)
+	{
+		upnp.DeletePortMapping(port);
 	}
 
 	/*********************************************************************************************/

--- a/scripts/Lobby.cs
+++ b/scripts/Lobby.cs
@@ -117,7 +117,7 @@ public partial class Lobby : Node
 		int clientIndex = 0;
 		foreach (var item in clients.Keys)
 		{
-			stringBuilder.Append(String.Format("{0}.\tClient : {1}\t({2})\n", clientIndex, item, clients[item].DEBUG_GetLifetime()));
+			stringBuilder.Append(String.Format("{0}.\tClient : {1}\n", clientIndex, item));
 			clientIndex++;
 		}
 
@@ -392,7 +392,6 @@ public partial class Lobby : Node
 		// Sync info to remote peers
 		int[] data = SerializeClients(clients);
 		Rpc(MethodName.RPC_SyncClientList, data);
-		// Rpc(MethodName.RPC_SpawnPlayerForClient, clientID);
 	}
 
 	protected void UnregisterClient(int clientID)
@@ -475,7 +474,7 @@ public partial class Lobby : Node
 
 		Client newClient = new Client(clientID);
 
-		newClient.OnRegisterClient();
+		newClient.OnRegisterClient(this, playerScene);
 		clientDictonary.Add(clientID, newClient);
 
 		return newClient;

--- a/scripts/network_planning.md
+++ b/scripts/network_planning.md
@@ -104,6 +104,8 @@ Represents a single connected player in the lobby. Contains only game agnostic i
 	SERVER ? Server sets authority of the player nodes
 	oh god this sucks
 
+	LETS MAKE IT THE CLIENTS PROBLEM!
+
 
 ## NetworkedNode
 Node that establishes a connection between Client and the Scene.

--- a/scripts/network_planning.md
+++ b/scripts/network_planning.md
@@ -93,6 +93,18 @@ Represents a single connected player in the lobby. Contains only game agnostic i
 	- Ping
 	- IsLocalPlayer()
 
+## Spawning players 
+- Every client has a player character node
+- All nodes need to be spawned across all instances BEFORE transfering authority to the client
+- So, 
+	SERVER : Registers client & syncs client lists
+	CLIENT : Updates client list (clients will need to be bound to their respective player nodes)
+	SERVER : Requests spawn
+	CLIENT : spawns player instances with correct authorities
+	SERVER ? Server sets authority of the player nodes
+	oh god this sucks
+
+
 ## NetworkedNode
 Node that establishes a connection between Client and the Scene.
 ? I'm not sure how godot handles things but these are componenty?


### PR DESCRIPTION
Clients now spawn a single "player node" on lobby registration. Each client holds network authority over their respective player node. Include an example DemoPlayer.cs that demonstrates client authoritative movement / synchronization.