### PR TITLE
Implement network time node.

### DIFF
--- a/godot-multiplayer.csproj.old.1
+++ b/godot-multiplayer.csproj.old.1
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.4.1">
+<Project Sdk="Godot.NET.Sdk/4.4.0">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/scenes/prefabs/lobby.tscn
+++ b/scenes/prefabs/lobby.tscn
@@ -26,5 +26,4 @@ text = "Clients"
 
 [node name="NetworkTime" type="Node" parent="." node_paths=PackedStringArray("debug_timeLabel")]
 script = ExtResource("3_sslvx")
-syncFrequency = 0.25
 debug_timeLabel = NodePath("../network_time")

--- a/scenes/prefabs/lobby.tscn
+++ b/scenes/prefabs/lobby.tscn
@@ -1,15 +1,28 @@
-[gd_scene load_steps=3 format=3 uid="uid://cdjo6xqp3diue"]
+[gd_scene load_steps=4 format=3 uid="uid://cdjo6xqp3diue"]
 
 [ext_resource type="Script" uid="uid://dcm5jeu2yntyw" path="res://scripts/Lobby.cs" id="1_uniae"]
 [ext_resource type="PackedScene" uid="uid://bpo3sey3ddxkt" path="res://scenes/prefabs/demo_player.tscn" id="2_sslvx"]
+[ext_resource type="Script" uid="uid://d1ee3nga55dog" path="res://scripts/NetworkTime.cs" id="3_sslvx"]
 
 [node name="Lobby" type="Node" node_paths=PackedStringArray("clientListDebugLabel")]
 script = ExtResource("1_uniae")
 playerScene = ExtResource("2_sslvx")
 clientListDebugLabel = NodePath("client_list")
 
+[node name="network_time" type="Label" parent="."]
+modulate = Color(1, 0.270588, 1, 1)
+offset_left = 79.0
+offset_top = 127.0
+offset_right = 560.0
+offset_bottom = 200.0
+text = "Clients"
+
 [node name="client_list" type="Label" parent="."]
 offset_top = 250.0
 offset_right = 481.0
 offset_bottom = 323.0
 text = "Clients"
+
+[node name="NetworkTime" type="Node" parent="." node_paths=PackedStringArray("debug_timeLabel")]
+script = ExtResource("3_sslvx")
+debug_timeLabel = NodePath("../network_time")

--- a/scenes/prefabs/lobby.tscn
+++ b/scenes/prefabs/lobby.tscn
@@ -15,6 +15,7 @@ offset_left = 79.0
 offset_top = 127.0
 offset_right = 560.0
 offset_bottom = 200.0
+theme_override_font_sizes/font_size = 90
 text = "Clients"
 
 [node name="client_list" type="Label" parent="."]
@@ -25,4 +26,5 @@ text = "Clients"
 
 [node name="NetworkTime" type="Node" parent="." node_paths=PackedStringArray("debug_timeLabel")]
 script = ExtResource("3_sslvx")
+syncFrequency = 0.25
 debug_timeLabel = NodePath("../network_time")

--- a/scenes/prefabs/lobby.tscn
+++ b/scenes/prefabs/lobby.tscn
@@ -9,21 +9,11 @@ script = ExtResource("1_uniae")
 playerScene = ExtResource("2_sslvx")
 clientListDebugLabel = NodePath("client_list")
 
-[node name="network_time" type="Label" parent="."]
-modulate = Color(1, 0.270588, 1, 1)
-offset_left = 79.0
-offset_top = 127.0
-offset_right = 560.0
-offset_bottom = 200.0
-theme_override_font_sizes/font_size = 90
-text = "Clients"
-
 [node name="client_list" type="Label" parent="."]
 offset_top = 250.0
 offset_right = 481.0
 offset_bottom = 323.0
 text = "Clients"
 
-[node name="NetworkTime" type="Node" parent="." node_paths=PackedStringArray("debug_timeLabel")]
+[node name="NetworkTime" type="Node" parent="."]
 script = ExtResource("3_sslvx")
-debug_timeLabel = NodePath("../network_time")

--- a/scripts/Lobby.cs
+++ b/scripts/Lobby.cs
@@ -48,6 +48,10 @@ public partial class Lobby : Node
 	[Export]
 	protected string version = "0.0.0";
 
+	// Default IP address used to bind hosted servers and to connect clients too.
+	[Export]
+	protected string ip = "192.168.0.1";
+
 	// Default port to use for creating / joining lobbies.
 	[Export]
 	protected int port = 7777;
@@ -143,9 +147,26 @@ public partial class Lobby : Node
 	/*********************************************************************************************/
 	/** Lobby */
 
-	// Starts server
-	public virtual Error Host(string bindIP)
+	public virtual Error StartServer()
 	{
+		return StartServer(ip, port, password);
+	}
+
+	public virtual Error StartServer(string bindIP)
+	{
+		return StartServer(bindIP, port);
+	}
+
+	public virtual Error StartServer(string bindIP, int portOverride)
+	{
+		return StartServer(bindIP, portOverride, password);
+	}
+
+	// Starts server
+	public virtual Error StartServer(string bindIP, int portOverride, string passwordOverride)
+	{
+		password = passwordOverride;
+
 		if (Multiplayer.MultiplayerPeer != null)
 		{
 			return Error.AlreadyExists;
@@ -163,12 +184,25 @@ public partial class Lobby : Node
 		Multiplayer.MultiplayerPeer = peer;
 		GD.Print(String.Format("Hosting server @ {0}:{1}.", bindIP, port));
 
-		// EnableUPNP(port);
-
 		return Error.Ok;
 	}
 
-	public virtual Error Connect(string address)
+	public virtual Error ConnectClient()
+	{
+		return ConnectClient(ip, port, password);
+	}
+
+	public virtual Error ConnectClient(string address)
+	{
+		return ConnectClient(address, port, password);
+	}
+
+	public virtual Error ConnectClient(string address, int portOverride)
+	{
+		return ConnectClient(address, portOverride, password);
+	}
+
+	public virtual Error ConnectClient(string address, int portOverride, string passwordOverride)
 	{
 		if (Multiplayer.MultiplayerPeer != null)
 		{
@@ -198,7 +232,6 @@ public partial class Lobby : Node
 		}
 
 		Multiplayer.MultiplayerPeer.Close();
-		// DisableUPNP(port);
 
 		return Error.Ok;
 	}

--- a/scripts/Menu.cs
+++ b/scripts/Menu.cs
@@ -27,7 +27,7 @@ public partial class Menu : Control
 
 	public void _on_host_button_down()
 	{
-		Error e = Lobby.GetLobbyInstance().Host(ipTextEdit.Text);
+		Error e = Lobby.GetLobbyInstance().StartServer(ipTextEdit.Text);
 		if (e != Error.Ok)
 		{
 			GD.Print(e.ToString());
@@ -36,7 +36,7 @@ public partial class Menu : Control
 
 	public void _on_join_button_down()
 	{
-		Error e = Lobby.GetLobbyInstance().Connect(ipTextEdit.Text);
+		Error e = Lobby.GetLobbyInstance().ConnectClient(ipTextEdit.Text);
 		if (e != Error.Ok)
 		{
 			GD.Print(e.ToString());

--- a/scripts/NetworkExtensions.cs
+++ b/scripts/NetworkExtensions.cs
@@ -23,7 +23,7 @@ public static class NetworkExtensions
 #endif
     }
 
-    // Throws an error if this node is not running on the server.
+    // Throws an error if this node is not running as a client connected to a server.
     public static void EnsureClient(this Node node)
     {
 #if DEBUG_NETWORKING

--- a/scripts/NetworkExtensions.cs
+++ b/scripts/NetworkExtensions.cs
@@ -1,0 +1,51 @@
+#define DEBUG_NETWORKING
+
+using Godot;
+
+public static class NetworkExtensions
+{
+    // Throws an error if this node is not running on the server.
+    public static void EnsureServer(this Node node)
+    {
+#if DEBUG_NETWORKING
+
+        if (!IsConnected(node))
+        {
+            return;
+        }
+
+        bool isServer = node.Multiplayer.IsServer();
+
+        if (!isServer)
+        {
+            throw new System.Exception("Attempted to run a server function on a non-server node.");
+        }
+#endif
+    }
+
+    // Throws an error if this node is not running on the server.
+    public static void EnsureClient(this Node node)
+    {
+#if DEBUG_NETWORKING
+
+        if (!IsConnected(node))
+        {
+            return;
+        }
+
+        bool isServer = node.Multiplayer.IsServer();
+
+        if (isServer)
+        {
+            throw new System.Exception("Attempted to run a client function on a non-client node.");
+        }
+#endif
+    }
+
+    private static bool IsConnected(Node node)
+    {
+        return node.Multiplayer.MultiplayerPeer != null
+            && node.Multiplayer.MultiplayerPeer.GetConnectionStatus()
+                == MultiplayerPeer.ConnectionStatus.Connected;
+    }
+}

--- a/scripts/NetworkExtensions.cs.uid
+++ b/scripts/NetworkExtensions.cs.uid
@@ -1,0 +1,1 @@
+uid://dg3qvsxroi7mn

--- a/scripts/NetworkTime.cs
+++ b/scripts/NetworkTime.cs
@@ -1,0 +1,100 @@
+using Godot;
+using System;
+
+
+/// PLANNING
+/// A) Syncronize the current time to all clients, each client ticks up its own time
+/// B) Syncronize an OFFSET to the scene load time to all clients 
+/// C) Sync a specified sync time to all clients, each caluclates its networkTime as an offset from that sync time
+
+public struct NetworkTimeSync
+{
+	public float currentNetworkTime;
+
+	public float currentLocalTime;
+
+	public NetworkTimeSync(float _currentNetworkTime, float _currentLocalTime)
+	{
+		currentNetworkTime = _currentNetworkTime;
+		currentLocalTime = _currentLocalTime;
+	}
+}
+
+// TODO : Track latency
+// TODO : The network time sync should be activate by the lobby 
+
+/// <summary>
+/// Node responsible for tracking network time across clients / server
+/// </summary>
+public partial class NetworkTime : Node
+{
+	/*********************************************************************************************/
+	/** Network Time */
+
+	[Export]
+	protected float syncFrequency = 1f;
+
+	private float nextSyncTime = 0;
+
+	private NetworkTimeSync latestNetworkTime = new NetworkTimeSync();
+
+	// Copy of network time exported for debugging purposes.
+	[Export]
+	private float debug_NetworkTime;
+
+	[Export]
+	private Label debug_timeLabel;
+
+	/*********************************************************************************************/
+	/** Engine Methods */
+
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready()
+	{
+	}
+
+	// Called every frame. 'delta' is the elapsed time since the previous frame.
+	public override void _Process(double delta)
+	{
+		if (Multiplayer.HasMultiplayerPeer() && Multiplayer.IsServer() && GetLocalTime() > nextSyncTime)
+		{
+			SyncNetworkTime();
+			nextSyncTime = 1f / syncFrequency;
+		}
+		ProcessDebugging();
+	}
+
+	/*********************************************************************************************/
+	/** Server */
+
+	protected void SyncNetworkTime()
+	{
+		Rpc(MethodName.RPC_SyncNetworkTime, GetLocalTime());
+	}
+
+	[Rpc(MultiplayerApi.RpcMode.Authority, CallLocal = false, TransferMode = MultiplayerPeer.TransferModeEnum.Reliable)]
+	private void RPC_SyncNetworkTime(float newNetworkTime)
+	{
+		latestNetworkTime = new NetworkTimeSync(newNetworkTime, GetLocalTime());
+	}
+
+	public float GetNetworkTime()
+	{
+		float offset = latestNetworkTime.currentNetworkTime - latestNetworkTime.currentLocalTime;
+		return GetLocalTime() + offset;
+	}
+
+	public float GetLocalTime()
+	{
+		return (float)Time.GetTicksMsec() / 1000f;
+	}
+
+	/*********************************************************************************************/
+	/** Debugging */
+
+	private void ProcessDebugging()
+	{
+		debug_NetworkTime = GetNetworkTime();
+		debug_timeLabel.Text = GetNetworkTime().ToString();
+	}
+}

--- a/scripts/NetworkTime.cs
+++ b/scripts/NetworkTime.cs
@@ -1,9 +1,6 @@
 using Godot;
 
-// TODO : Modular architecture for the NetworkManager class? I feel this should not be its own node
 // TODO : Documentation
-// TODO : Godot C# standards
-//
 // TODO : Investigate the effect of join time (and by extension relative placement of pings and time syncs)
 // TODO : Randomize ping / sync frequencies
 
@@ -85,6 +82,7 @@ public partial class NetworkTime : Node
     /*********************************************************************************************/
     /** Time */
 
+    // Returns the current time in seconds. Synchronised with the server.
     public float GetNetworkTime()
     {
         if (Multiplayer.MultiplayerPeer != null && Multiplayer.IsServer())
@@ -98,6 +96,7 @@ public partial class NetworkTime : Node
         }
     }
 
+    // Returns the current LOCAL time in seconds. Not synced on the network.
     public float GetLocalTime()
     {
         return (float)Time.GetTicksMsec() / 1000f;

--- a/scripts/NetworkTime.cs.uid
+++ b/scripts/NetworkTime.cs.uid
@@ -1,0 +1,1 @@
+uid://d1ee3nga55dog

--- a/scripts/network_planning.md
+++ b/scripts/network_planning.md
@@ -1,30 +1,37 @@
-# Multiplayer Game Framework within Godot.
+# Multiplayer Game Framework within Godot
+
 Let's make some tools around multiplayer development in Godot!
 
 These should be relatively agnostic to the networking backend (Web vs ENET, etc)
 
 ## Network Manager
+
 We are going to need a Node to handle the following:
-1) Hosting Servers
-2) Joining Servers
-3) Host Client-Server
-3) Keeping track of connected players
+
+1. Hosting Servers
+2. Joining Servers
+3. Host Client-Server
+4. Keeping track of connected players
 
 ### Feature Creep
-4) Kicking / Banning players
-5) Password Protection / connection validation
+
+4. Kicking / Banning players
+5. Password Protection / connection validation
 
 ## Server
-Maintain and synchronize variables to clients as needed. 
+
+Maintain and synchronize variables to clients as needed.
 
 Send data to ALL clients.
 
 Send data to a SINGLE client.
 
 ### FEATURE CREEP
-* Players could express a level of interest (0-255) in other players that determins what players need updates.
+
+- Players could express a level of interest (0-255) in other players that determins what players need updates.
 
 ## Clients
+
 Represent a connection to a server. Not the players character but everything else.
 
 I'm not sure if we actually need this
@@ -43,13 +50,13 @@ UpdateRemote()
 ### Bit (un)packing utils
 
 ### More granular multiplayer sync
+
 this could be a cool excuse to mod the engine a bit, I'd like a version of the multiplayer synchronizer that supports more granualar control over what is sent over network.
 
-For exmaple, each "sync" propery would have its own send (to server AND from server) rates which could be changed at real time and synced across (e.g. sync 10Hz for cleints of lower interest to a given player VS 24hz for those of interest, etc) 
-
-
+For exmaple, each "sync" propery would have its own send (to server AND from server) rates which could be changed at real time and synced across (e.g. sync 10Hz for cleints of lower interest to a given player VS 24hz for those of interest, etc)
 
 # NOTES ON GODOT NETWORKING
+
 - Pretty standard so far
 - Names of nodes (e.g. exact paths) are used for syncing RPC targets
 - RPCs can be sent to specific / all clients easily
@@ -68,46 +75,48 @@ For exmaple, each "sync" propery would have its own send (to server AND from ser
 - The unique ID is not assigned sequntially, its just a random number (host is always 1!)
 - Multiplayer State is determined by a parent root node of a scene, it might be possible to load a Client and Server scene under the same node?
 
-
-
 # Arch A
 
 ## ?
+
 - Shared interface for serializing objects for network transport
 
 ## Lobby
+
 Handles low level connections and disconnections.
 
 - Features
-	- Hosting 
-	- Connection
-	- Tracking connected clients
-	- Authenticating players connections
-	- Initializing players
+  - Hosting
+  - Connection
+  - Tracking connected clients
+  - Authenticating players connections
+  - Initializing players
 
 ## Client
+
 Represents a single connected player in the lobby. Contains only game agnostic information
 
 - Features
-	- IP
-	- Ping
-	- IsLocalPlayer()
+  - IP
+  - Ping
+  - IsLocalPlayer()
 
-## Spawning players 
+## Spawning players
+
 - Every client has a player character node
 - All nodes need to be spawned across all instances BEFORE transfering authority to the client
-- So, 
-	SERVER : Registers client & syncs client lists
-	CLIENT : Updates client list (clients will need to be bound to their respective player nodes)
-	SERVER : Requests spawn
-	CLIENT : spawns player instances with correct authorities
-	SERVER ? Server sets authority of the player nodes
-	oh god this sucks
+- So,
+  SERVER : Registers client & syncs client lists
+  CLIENT : Updates client list (clients will need to be bound to their respective player nodes)
+  SERVER : Requests spawn
+  CLIENT : spawns player instances with correct authorities
+  SERVER ? Server sets authority of the player nodes
+  oh god this sucks
 
-	LETS MAKE IT THE CLIENTS PROBLEM!
-
+  LETS MAKE IT THE CLIENTS PROBLEM!
 
 ## NetworkedNode
+
 Node that establishes a connection between Client and the Scene.
 ? I'm not sure how godot handles things but these are componenty?
 


### PR DESCRIPTION
## Overview
Network time is synced to the servers local time as defined by Godot. Network time is corrected by smoothed ping. Network time is synchronized at a fixed frequency (1 per second).


![image](https://github.com/user-attachments/assets/e9985898-eb42-4119-9e99-e24165332e7d)
Very small discrepancies in network time between clients despite very poor network conditions.

## Future Work
- Ignore outliers in smoothed ping calculations. Currently uses weighted convex combination which is very effective as a lowpass, but will likely still benefit from some sort of tunable threshold for detecting ping outliers. (perhaps ignore pings that fall outside of N standard deviations?)  
- Investigate effects investigate the effect of join time (and by extension relative placement of pings / time syncs), maybe some small amount of randomness or uniform distribution would help here. Or perhaps I'm over thinking this a bit & network randomness will negate this.
